### PR TITLE
Added Sekiro FPS region fix and new aspect ratio feature

### DIFF
--- a/trainers/sekiro.toml
+++ b/trainers/sekiro.toml
@@ -29,7 +29,7 @@ delay=2000
 # pattern = "C7 43 __ __ __ __ __ 4C 89 AB"
 [[feature]]
 name = "Set FPS Framelock"
-region = [5387235709, 5387235719]
+region = [5387236685, 5387236695]
 pattern = "C7 43 __ __ 88 88 3C 4C 89 AB"
 replace = "__ __ __ 0C 98 C6 3B __ __ __"
 enable = false

--- a/trainers/sekiro.toml
+++ b/trainers/sekiro.toml
@@ -35,6 +35,18 @@ replace = "__ __ __ 0C 98 C6 3B __ __ __"
 enable = false
 
 # Pattern taken from Sekiro FPS Unlock And More project:
+# https://github.com/uberhalit/SekiroFpsUnlockAndMore/blob/d6312c6b0af0bcdf987568e1490b7d842548ae99/SekiroFpsUnlockAndMore/GameData.cs#L140
+#
+# This changes a fixed 16:9 aspect ratio to a free-adjustable aspect-ratio based on resolution.
+# This does not add additional resolutions in the game.
+[[feature]]
+name = "Disable 16:9 aspect ratio lock."
+region = [5369932904, 5369932920]
+pattern = "85 C9 74 __ 47 8B __ __ __ __ __ __ 45 __ __ 74"
+replace = "90 90 EB __ 47 8B __ __ __ __ __ __ 45 __ __ 74"
+enable = false
+
+# Pattern taken from Sekiro FPS Unlock And More project:
 # https://github.com/uberhalit/SekiroFpsUnlockAndMore/blob/d6312c6b0af0bcdf987568e1490b7d842548ae99/SekiroFpsUnlockAndMore/GameData.cs#L44
 # Hex values calculated using the following python script:
 #    import struct

--- a/trainers/sekiro.toml
+++ b/trainers/sekiro.toml
@@ -38,7 +38,7 @@ enable = false
 # https://github.com/uberhalit/SekiroFpsUnlockAndMore/blob/d6312c6b0af0bcdf987568e1490b7d842548ae99/SekiroFpsUnlockAndMore/GameData.cs#L140
 #
 # This changes a fixed 16:9 aspect ratio to a free-adjustable aspect-ratio based on resolution.
-# This does not add additional resolutions in the game.
+# Make sure to play in Fullscreen mode, as widescreen resolutions are not present in window mode. This feature does not add additional resolutions.
 [[feature]]
 name = "Disable 16:9 aspect ratio lock."
 region = [5369932904, 5369932920]

--- a/trainers/sekiro.toml
+++ b/trainers/sekiro.toml
@@ -1,5 +1,5 @@
 name = "Sekiro Trainer"
-version = '0.0.2'
+version = '0.0.3'
 process = "sekiro.exe"
 enable = false
 

--- a/trainers/sekiro.toml
+++ b/trainers/sekiro.toml
@@ -29,7 +29,8 @@ delay=2000
 # pattern = "C7 43 __ __ __ __ __ 4C 89 AB"
 [[feature]]
 name = "Set FPS Framelock"
-region = [5387236685, 5387236695]
+# region = [5387235709, 5387235719]
+# region = [5387236685, 5387236695]
 pattern = "C7 43 __ __ 88 88 3C 4C 89 AB"
 replace = "__ __ __ 0C 98 C6 3B __ __ __"
 enable = false


### PR DESCRIPTION
The FPS memory location was off for me, so I ran it without and used the suggested memory location by the trainer in a subsequent test. For me the regions as they are in the file now work splendidly, but I am not sure if they need to be wider in case it is different on other systems.

As my monitor is 3440x1440 with 165 hz refresh, that is the settings I tested with. FPS changes work with windowed and fullscreen, while the aspect ratio change is for Fullscreen only. For the latter I made a note in the sekiro.toml.

Changing resolution and window modes do not affect the applied patches as far as I could tell (so, no need to apply fixes again when switching settings). Will play the game again to test it more thoroughly and see how stable it is (nice excuse to replay the game).

![Screenshot from 2023-01-24 12-53-09](https://user-images.githubusercontent.com/61807052/214288826-b7f80977-9356-4f51-8945-c33bb7c54dea.png)
