### PR TITLE
Update eldenring.toml with aspect ratio fix

### DIFF
--- a/trainers/eldenring.toml
+++ b/trainers/eldenring.toml
@@ -35,7 +35,7 @@
 #	- https://github.com/techiew/EldenRingMods
 # -----------------------------------------------------------------------
 name = "Elden Ring Trainer"
-version = '0.0.3'
+version = '0.0.4'
 process = "eldenring.exe"
 enable = false
 

--- a/trainers/eldenring.toml
+++ b/trainers/eldenring.toml
@@ -79,9 +79,9 @@ enable = false
 
 [[feature]]
 name = "Aspect Ratio Unlock"
-region = [5395287331, 5395287348]
-pattern = "8B __ 85 __ 74 __ 44 8B __ __ 45 85 __ 74 __ 41 8B"
-replace = "__ __ __ __ EB __ __ __ __ __ __ __ __ __ __ __ __"
+# region = [5395580718, 5395580724]
+pattern = "74 4f 45 8b 94 CC"
+replace = "EB __ __ __ __ __"
 enable = false
 
 # Increases animation distance


### PR DESCRIPTION
The aspect ratio feature did not work, as pattern was not found. This was not fixed by commenting out the region, so it was just not there.

In er-patcher project I found [a different pattern](https://github.com/gurrgur/er-patcher/blob/1a3e191ee9eb942a8c6f9140316a76dc8d2f7ca5/er-patcher#L58), which when applied to the trainer did work. Just as with the FPS/HZ patches, it is sketchy, maybe because it needs to be applied before the game reaches a certain condition.

The old pattern is still there in other FPS unlocker mods. So it may have been a change in one of the latest patches (current: 1.10), which also broke the others, or there are two methods to get to the same result.